### PR TITLE
MAKEHDI: Fix NHD header size

### DIFF
--- a/makehdi/makehdi.c
+++ b/makehdi/makehdi.c
@@ -472,7 +472,7 @@ int buildHDHeader(int hdtype)
             rc = setupHDHeader_hdi(header, optC, optH, optS, optB);
             break;
         case DISK_NHD:
-            header_size = HDI_HEADERSIZE;
+            header_size = NHD_HEADERSIZE;
             header = my_malloc(header_size);
             rc = setupHDHeader_nhd(header, optC, optH, optS, optB);
             break;


### PR DESCRIPTION
xnp2で作った`.nhd`より微妙にサイズが大きかったので気が付きました。